### PR TITLE
👷 Add code coverage for rustdoc doctests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
   push:
+    branches: main
 jobs:
   coverage:
     name: Code Coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,13 +53,14 @@ jobs:
           command: install
           args: grcov
       - name: Run Tests (coverage)
-        uses: actions-rs/cargo@v1
-        with:
-          command: hack
-          args: test --profile coverage --locked --each-feature
+        run: cargo +nightly hack test --profile=coverage --locked --each-feature
         env:
           LLVM_PROFILE_FILE: target/coverage/outcome-%p-%m.profraw
-          RUSTDOCFLAGS: -Zinstrument-coverage -Zprofile -Z unstable-options --preserve-doctests target/coverage
+          RUSTDOCFLAGS: >-
+            -Zinstrument-coverage
+            -Zprofile
+            -Zunstable-options
+            --preserve-doctests ${{github.workspace}}/target/coverage
           RUSTFLAGS: -Zinstrument-coverage -Zprofile
       - name: Collect Coverage
         run: >-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,11 +58,7 @@ jobs:
           args: test --profile coverage --locked --each-feature
         env:
           LLVM_PROFILE_FILE: target/coverage/outcome-%p-%m.profraw
-          RUSTDOCFLAGS: >-
-            -Zinstrument-coverage
-            -Zprofile
-            -Zunstable-options
-            --preserve-doctests ${{github.workspace}}/target/coverage
+          RUSTDOCFLAGS: -Zinstrument-coverage -Zprofile -Z unstable-options --preserve-doctests target/coverage
           RUSTFLAGS: -Zinstrument-coverage -Zprofile
       - name: Collect Coverage
         run: >-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -58,8 +58,12 @@ jobs:
           args: test --profile coverage --locked --each-feature
         env:
           LLVM_PROFILE_FILE: target/coverage/outcome-%p-%m.profraw
-          RUSTDOCFLAGS: -Zinstrument-coverage
-          RUSTFLAGS: -Zinstrument-coverage
+          RUSTDOCFLAGS: >-
+            -Zinstrument-coverage
+            -Zprofile
+            -Zunstable-options
+            --preserve-doctests ${{github.workspace}}/target/coverage
+          RUSTFLAGS: -Zinstrument-coverage -Zprofile
       - name: Collect Coverage
         run: >-
           grcov ${{github.workspace}}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,14 +53,17 @@ jobs:
           command: install
           args: grcov
       - name: Run Tests (coverage)
-        run: cargo +nightly hack test --profile=coverage --locked --each-feature
+        uses: actions-rs/cargo@v1
+        with:
+          command: hack
+          args: test --profile=coverage --locked --each-feature
         env:
           LLVM_PROFILE_FILE: target/coverage/outcome-%p-%m.profraw
           RUSTDOCFLAGS: >-
             -Zinstrument-coverage
             -Zprofile
             -Zunstable-options
-            --preserve-doctests ${{github.workspace}}/target/coverage
+            --persist-doctests ${{github.workspace}}/target/coverage
           RUSTFLAGS: -Zinstrument-coverage -Zprofile
       - name: Collect Coverage
         run: >-

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@
 set shell := ["pwsh", "-NoProfile", "-NoLogo", "-Command"]
 
 rustflags := "-Zinstrument-coverage -Zprofile"
-rustdocflags := rustflags + " -Z unstable-options --persist-doctests target/debug/doctest"
+rustdocflags := rustflags + " -Z unstable-options --persist-doctests target/coverage"
 coverage := join(justfile_directory(), "target/coverage/outcome-%p-%m.profraw")
 pwd := justfile_directory()
 
@@ -22,7 +22,7 @@ default: fmt test
     --output-type {{type}} \
     --output-path {{ if type == "lcov" { "coverage.info" } else { "target/collected" } }} \
     --commit-sha $(git rev-parse HEAD) \
-    --binary-path {{pwd}}/target/debug \
+    --binary-path {{pwd}}/target/coverage \
     --prefix-dir {{pwd}} \
     --filter covered \
     --branch \


### PR DESCRIPTION
This adjusts both the github actions workflow *and* the `just collect` build target 