### PR TITLE
⬇️ Downgrade miette minimum version to 3.0.0, fix semver range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 eyre = { version = "0.6.5", optional = true }
-miette = { version = "4.0.0", optional = true }
+miette = { version = ">=3.0.0", optional = true }
 
 [build-dependencies]
 rustversion = "1.0.6"


### PR DESCRIPTION
This resolves an issue where we can interact with miette versions 3.x or
later, but we had hard pinned to 4.0.0.
